### PR TITLE
Improved language

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "strum_macros",
  "thiserror",
  "time",
  "tokio",
@@ -1083,12 +1082,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
-name = "rustversion"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
-
-[[package]]
 name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,19 +1231,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
 
 [[package]]
 name = "supports-color"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ rust-toolchain-version = "1.67.1"
 # CI backends to support (see 'cargo dist generate-ci')
 ci = ["github"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = [
-    "x86_64-unknown-linux-gnu",
-    "x86_64-apple-darwin",
-    "x86_64-pc-windows-msvc",
-]
+#targets = [
+#    "x86_64-unknown-linux-gnu",
+#    "x86_64-apple-darwin",
+#    "x86_64-pc-windows-msvc",
+#]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ time = { version = "0.3.11", features = ["formatting", "macros"] }
 mime_guess = "2.0.4"
 indicatif = "0.16.2"
 itertools = "0.10.3"
-strum_macros = "0.24"
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Use a base image that matches the target platform
 FROM ubuntu:latest
+#FROM mcr.microsoft.com/windows/servercore:<version>
 
 # Install any necessary dependencies or libraries required by your program
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use a base image that matches the target platform
+FROM ubuntu:latest
+
+# Install any necessary dependencies or libraries required by your program
+RUN apt-get update && apt-get install -y \
+    libssl-dev \
+    libcurl4-openssl-dev \
+    pkg-config \
+    libpq-dev
+    
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the compiled binary into the image
+COPY target/release/ .
+RUN mkdir audio
+COPY audio/** audio/
+
+# Expose any necessary ports for your program (if applicable)
+EXPOSE 8080
+
+# Set the entry point or command to run your program when the container starts
+CMD ["./lamarck"]

--- a/README.md
+++ b/README.md
@@ -52,3 +52,54 @@ Lamarck is short for [Lamarckdromia Beagle](https://hu.wikipedia.org/wiki/Lamarc
 ##### Forking Notes
 We added a `--lang flag`
 usage is now `target/debug/lamarck caption --deepgram-api-key <key> --input test_german.mp3 --lang de`
+
+history log
+
+ 1119  target/debug/lamarck caption --deepgram-api-key bce30426da3ae2e613e3a5ae459f0a70e533f515 --input audio/test_german.mp3 --lang de
+ 1120  mkdir audio
+ 1121  target/debug/lamarck caption --deepgram-api-key bce30426da3ae2e613e3a5ae459f0a70e533f515 --input audio/test_german.mp3 --lang de
+ 1122  gst
+ 1123  gst 
+ 1124  git add .
+ 1125  git commit -m"remove strum, and string match enum languages"
+ 1126  git push
+ 1127  cargo build --release
+ 1128  gst
+ 1129  git push
+ 1130  touch Dockerfile
+ 1131  docker
+ 1132  docker run -p 8080:8080 my_program_image
+ 1133  cargo clean
+ 1134  cargo build --release --verbose
+ 1135  cd target/
+ 1136  cd release/
+ 1137  ls -la
+ 1138  cd ..
+ 1139  docker build -t lamarck
+ 1140  docker build -t lamarck .
+ 1141  docker run -it lamarck /bin/bash
+ 1142  docker images
+ 1143  docker build -t lamarck .
+ 1144  docker run -it lamarck /bin/bash
+ 1145  docker images
+ 1147  docker run -it lamarck /bin/bash
+ 1148  docker build -t lamarck .
+ 1161  cargo clean
+ 1162  cargo build --release --verbose
+ 1163  docker build -t lamarck .
+ 1164  docker run -it lamarck /bin/bash
+ 1165  cargo clean
+ 1166  cargo build --release --verbose --target x86_64-pc-windows-msvc
+ 1167  cargo build --release --verbose
+ 1168  docker build -t lamarck .
+ 1169  docker run -it lamarck /bin/bash
+ 1170  cargo clean
+ 1171  cargo build --release --verbose --target x86_64-pc-windows-msvc
+ 1172  rustup target add x86_64-pc-windows-msvc
+ 1173  cargo clean
+ 1174  cargo build --release --verbose --target x86_64-pc-windows-msvc
+ 1175  docker build -t lamarck .
+ 1176  docker run -it lamarck /bin/bash
+ 1177  cargo clean
+ 1178  cargo build --release --verbose --target x86_64-unknown-linux-gnu
+ 1179  history 500

--- a/src/captions.rs
+++ b/src/captions.rs
@@ -77,14 +77,11 @@ pub struct Caption {
     transcript: bool,
     /// output a markdown file with links to video
     /// timestamps
-    #[clap(short, long, help_heading = "OUTPUT_TYPE")]
-    lang: Option<String>,
-    /// argument to specify the language of the audio
     #[clap(
         short,
         long,
         default_value_t = false,
-        help_heading = "language"
+        help_heading = "OUTPUT_TYPE"
     )]
     markdown: bool,
 }
@@ -211,28 +208,12 @@ pub async fn generate_captions(
         }
     }?;
 
-    let language = match options.lang.as_ref() {
-        Some(lang) => match lang.as_str() {
-            "de" => Language::de,
-            "en" => Language::en,
-            "es" => Language::es,
-            "fr" => Language::fr,
-            "it" => Language::it,
-            "ja" => Language::ja,
-            "ko" => Language::ko,
-            "pt" => Language::pt,
-            "zh" => Language::zh,
-            _ => Language::en,
-        },
-        None => Language::en,
-    };
-
     let dg_client =
         Deepgram::new(&options.deepgram_api_key);
 
     let deepgram_options = Options::builder()
         .punctuate(true)
-        .language(language)
+        .language(Language::en_US)
         .utterances(true)
         .build();
 

--- a/src/captions.rs
+++ b/src/captions.rs
@@ -77,12 +77,9 @@ pub struct Caption {
     transcript: bool,
     /// output a markdown file with links to video
     /// timestamps
-    #[clap(
-        short,
-        long,
-        default_value_t = false,
-        help_heading = "OUTPUT_TYPE"
-    )]
+    #[clap(short, long, help_heading = "OUTPUT_TYPE")]
+    lang: Option<String>,
+    #[clap(short, long, help_heading = "Language")]
     markdown: bool,
 }
 
@@ -208,12 +205,50 @@ pub async fn generate_captions(
         }
     }?;
 
+    fn map_string_to_language(string: &str) -> Language {
+        match string {
+            "zh" => Language::zh,
+            "zh_cn" => Language::zh_CN,
+            "zh_tw" => Language::zh_TW,
+            "nl" => Language::nl,
+            "en" => Language::en,
+            "en_au" => Language::en_AU,
+            "en_gb" => Language::en_GB,
+            "en_in" => Language::en_IN,
+            "en_nz" => Language::en_NZ,
+            "en_us" => Language::en_US,
+            "fr" => Language::fr,
+            "fr_ca" => Language::fr_CA,
+            "de" => Language::de,
+            "hi" => Language::hi,
+            "hi_latn" => Language::hi_Latn,
+            "id" => Language::id,
+            "it" => Language::it,
+            "ja" => Language::ja,
+            "ko" => Language::ko,
+            "pt" => Language::pt,
+            "pt_br" => Language::pt_BR,
+            "ru" => Language::ru,
+            "es" => Language::es,
+            "es_419" => Language::es_419,
+            "sv" => Language::sv,
+            "tr" => Language::tr,
+            "uk" => Language::uk,
+            _ => Language::en, // Default to Language::En for unknown strings
+        }
+    }
+
+    let language = match options.lang.as_ref() {
+        Some(language) => map_string_to_language(language),
+        None => Language::en_US,
+    };
+
     let dg_client =
         Deepgram::new(&options.deepgram_api_key);
 
     let deepgram_options = Options::builder()
         .punctuate(true)
-        .language(Language::en_US)
+        .language(language)
         .utterances(true)
         .build();
 


### PR DESCRIPTION
* i had to remove strum_macros. since i used it in the deepgram options to `#[derive(strum::*)]` which is wrong,. i forget about this "prequisite" to make it work and deliver now a more common stringy way to match the langue Type for the deepgram::builder.
sorry it's taking your time. I am using your crate to give a talk on the rust compiler targets here https://berline.rs 
this is why i fiddeld with it.

so either merge this, or undo the one before, it will break at `cargo build --release` 
cheers and now finally 🖖🏼 